### PR TITLE
Don't return `true` when SMS returns {error: true, ...}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 Quiubas Changelog
 ====================
+Version 1.3.3
+-------------
+Released March 12, 2019
+
+- Fix error handling if api returns {"error":true}
+
 Version 1.3.1
 -------------
 Released November 1, 2018

--- a/lib/network.js
+++ b/lib/network.js
@@ -58,7 +58,7 @@ Network.prototype.request = function(path, params, method, success_callback, err
       }
       url += params_list.join('&');
     }
-	
+
   }
 
   request_info.uri = url;
@@ -104,7 +104,15 @@ Network.prototype.request = function(path, params, method, success_callback, err
 
           error_msg = error_msg.join('\n');
         } else {
-          error_msg = response.error;
+            if (response.error === true) {
+                error_msg = [
+                    response.code,
+                    '-',
+                    response.message
+                ].join(' ');
+            } else {
+                error_msg = response.error;
+            }
         }
       }
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -105,11 +105,7 @@ Network.prototype.request = function(path, params, method, success_callback, err
           error_msg = error_msg.join('\n');
         } else {
             if (response.error === true) {
-                error_msg = [
-                    response.code,
-                    '-',
-                    response.message
-                ].join(' ');
+                error_msg = response.message;
             } else {
                 error_msg = response.error;
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quiubas/quiubas-node",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Quiubas NodeJS Library for REST API",
   "main": "lib/quiubas.js",
   "scripts": {


### PR DESCRIPTION
As described on https://docs.quiubas.com/api?active=errors, the `response.error` property is a boolean. 
The code was throwing the boolean value as the error. 
My change throws the `response.message` string as value when an error occurs.

Note: In my opinion it should throw an Error() object instead of a string value, but I'm not changing that for backward compatibility reasons.
